### PR TITLE
use clap with env and value_hint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3.11", features = ["derive"] }
+clap = { version = "4.3.11", features = ["derive", "env"] }
 memmem = "0.1.1"
 quick-xml = { version = "0.29.0", features = ["serialize"] }
 serde = "1.0.171"


### PR DESCRIPTION
I saw @n0emis forking this, looked into this and thought the cli stuff can be optimized.

Also a Rust pitfall I noticed with the previous env logic:

```diff
-let ssh_user = cli.user.unwrap_or(env::var("USER").unwrap());
+let ssh_user = cli.user.unwrap_or_else(|| env::var("USER").unwrap());
```

When the user was specified the env::var logic was still executed. `unwrap_or` shouldn't be used with a function especially when it can fail. As clap is now handling the env variable logic this pitfall is now gone.

I'm not fully aware was this code does but parts look fairly similar to my [`remoterun` bash script](https://github.com/EdJoPaTo/LinuxScripts/blob/a2290264cc3bf631d23d18951b743f4e282c987a/configs/bin/remoterun).
The command stuff on cli is similar to my `project-below` tool from which I took the [cli thingies](https://github.com/EdJoPaTo/project-below/blob/main/src/cli.rs).

ValueHint is used on completion generation which this project currently isn't doing.
Personally I use a separate `src/cli.rs` file and create a `build.rs` which automatically generates completion files on build.